### PR TITLE
actions: create release action

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,21 @@
+# This action creates a release every Monday at 5:00 UTC.
+name: "Create and push release tag"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1"
+
+jobs:
+  tag-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Upstream tag
+        uses: osbuild/release-action@create-tag
+        with:
+          token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
+          username: "imagebuilder-bot"
+          email: "imagebuilder-bots+imagebuilder-bot@redhat.com"
+          semver: "true"
+          semver_bump_type: "minor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: "Create GitHub release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upstream release
+        uses: osbuild/release-action@main
+        with:
+          token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
+          slack_webhook_url: "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
Create a release action for the pulp-client repo so that updates to the client are propogated automatically to composer via dependabot, as is the case with `osbuild/images`.